### PR TITLE
fix:  「TypeScript型の自動生成システム」ページの移動

### DIFF
--- a/src/lib/config/sidebar.ts
+++ b/src/lib/config/sidebar.ts
@@ -94,7 +94,7 @@ export const sidebarConfig: { [key: string]: SidebarItem[] } = {
             { title: '基礎編概要', to: '/sveltekit/basics/' },
             { title: 'SvelteKit概要', to: '/sveltekit/basics/overview/' },
             { title: 'プロジェクト構造', to: '/sveltekit/basics/project-structure/' },
-            { title: 'TypeScript型の自動生成システム', to: '/sveltekit/basics/auto-types/' },
+            { title: 'app.d.tsの役割', to: '/sveltekit/basics/global-types/' },
           ],
         },
         {
@@ -115,6 +115,7 @@ export const sidebarConfig: { [key: string]: SidebarItem[] } = {
           items: [
             { title: 'Load関数とデータフェッチング', to: '/sveltekit/data-loading/' },
             { title: 'Load関数の基礎', to: '/sveltekit/data-loading/basic/' },
+            { title: 'TypeScript型の自動生成システム', to: '/sveltekit/data-loading/auto-types/' },
             { title: 'データフェッチング戦略', to: '/sveltekit/data-loading/strategies/' },
           ],
         },

--- a/src/routes/sveltekit/+page.md
+++ b/src/routes/sveltekit/+page.md
@@ -125,8 +125,8 @@ SvelteKitは、Svelteをベースにした**モダンなフルスタックWebア
             <td class="py-2 text-gray-6 dark:text-gray-4">ファイル構成と規約</td>
           </tr>
           <tr>
-            <td class="py-2"><a href="{base}/sveltekit/basics/auto-types/" class="text-blue-600 dark:text-blue-400 hover:underline">TypeScript型の自動生成</a></td>
-            <td class="py-2 text-gray-6 dark:text-gray-4">./$typesによる型安全な開発</td>
+            <td class="py-2"><a href="{base}/sveltekit/basics/global-types/" class="text-blue-600 dark:text-blue-400 hover:underline">app.d.tsの役割</a></td>
+            <td class="py-2 text-gray-6 dark:text-gray-4">グローバルな型定義</td>
           </tr>
         </tbody>
       </table>
@@ -201,6 +201,10 @@ SvelteKitは、Svelteをベースにした**モダンなフルスタックWebア
           <tr>
             <td class="py-2"><a href="{base}/sveltekit/data-loading/basic/" class="text-orange-600 dark:text-orange-400 hover:underline">Load関数の基本</a></td>
             <td class="py-2 text-gray-6 dark:text-gray-4">Universal LoadとServer Load</td>
+          </tr>
+          <tr>
+            <td class="py-2"><a href="{base}/sveltekit/data-loading/auto-types/" class="text-orange-600 dark:text-orange-400 hover:underline">TypeScript型の自動生成</a></td>
+            <td class="py-2 text-gray-6 dark:text-gray-4">./$typesによる型安全な開発</td>
           </tr>
           <tr>
             <td class="py-2"><a href="{base}/sveltekit/data-loading/strategies/" class="text-orange-600 dark:text-orange-400 hover:underline">データフェッチング戦略</a></td>
@@ -434,7 +438,7 @@ npm create svelte@latest my-first-sveltekit-app
 ### Step 1: 基礎理解（1-2日）
 1. **[概要とアーキテクチャ]({base}/sveltekit/basics/overview/)** - SSR/SSG/SPAの違いとSvelteKitの位置づけを理解
 2. **[プロジェクト構造]({base}/sveltekit/basics/project-structure/)** - `routes/`、`+page.svelte`、`+layout.svelte`の役割を把握
-3. **[TypeScript型の自動生成]({base}/sveltekit/basics/auto-types/)** - `./$types`による型安全な開発を体験
+3. **[app.d.tsの役割]({base}/sveltekit/basics/global-types/)** - グローバルな型定義の設定方法を理解
 
 ### Step 2: コア機能習得（3-5日）
 1. **[基本ルーティング]({base}/sveltekit/routing/basic/)** - ファイルベースルーティングで最初のページを作成

--- a/src/routes/sveltekit/basics/+page.md
+++ b/src/routes/sveltekit/basics/+page.md
@@ -60,20 +60,20 @@ SvelteKitは、モダンなWebアプリケーション開発に必要なすべ�
     </div>
   </a>
 
-  <a href="{base}/sveltekit/basics/auto-types/" class="flex no-underline group h-full">
+  <a href="{base}/sveltekit/basics/global-types/" class="flex no-underline group h-full">
     <div class="p-4 border border-gray-2 dark:border-gray-7 rounded-lg shadow-md hover:shadow-lg hover:border-blue-400 dark:hover:border-blue-400 transition-all cursor-pointer flex flex-col w-full">
-      <div class="text-3xl mb-2">🔷</div>
+      <div class="text-3xl mb-2">🌍</div>
       <h3 class="font-bold text-lg mb-2 text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300 transition-colors">
-        TypeScript型の自動生成システム
+        app.d.tsの役割
         <span class="inline-block ml-1 text-xs opacity-60">→</span>
       </h3>
-      <p class="text-sm mb-3 text-gray-7 dark:text-gray-3">SvelteKitが提供する./$typesによる型安全な開発</p>
+      <p class="text-sm mb-3 text-gray-7 dark:text-gray-3">プロジェクト全体で共有されるグローバルな型定義</p>
       <ul class="text-sm text-gray-6 dark:text-gray-4 space-y-1 flex-grow">
-        <li><strong>./$types</strong>: 仮想モジュールの仕組み</li>
-        <li><strong>型の一覧</strong>: PageLoad, Actions, RequestHandler等</li>
-        <li><strong>実践例</strong>: 各ファイルタイプでの使用方法</li>
-        <li><strong>app.d.ts連携</strong>: グローバル型定義との統合</li>
-        <li><strong>トラブルシューティング</strong>: よくある問題と解決策</li>
+        <li><strong>App.Locals</strong>: サーバーサイドのリクエスト固有データ</li>
+        <li><strong>App.PageData</strong>: すべてのページで共通のデータ型</li>
+        <li><strong>App.Error</strong>: カスタムエラー型</li>
+        <li><strong>App.PageState</strong>: 履歴エントリの状態</li>
+        <li><strong>App.Platform</strong>: プラットフォーム固有のAPI</li>
       </ul>
     </div>
   </a>

--- a/src/routes/sveltekit/basics/global-types/+page.md
+++ b/src/routes/sveltekit/basics/global-types/+page.md
@@ -1,0 +1,475 @@
+---
+title: app.d.tsの役割
+description: SvelteKitのapp.d.tsでグローバルな型定義を設定 - App.Locals、App.PageData、App.Errorなど標準インターフェースの完全ガイド
+---
+
+<script lang="ts">
+  import { base } from '$app/paths';
+</script>
+
+SvelteKitでは`app.d.ts`ファイルを通じて、プロジェクト全体で使用するグローバルな型定義を宣言できます。これらの型は`./$types`と自動的に統合され、アプリケーション全体で型安全性を保証します。
+
+## app.d.tsの役割
+
+`app.d.ts`は、SvelteKitアプリケーション全体で共有される型定義の中心となるファイルです。ここで定義した型は、すべてのルート、コンポーネント、サーバーサイドコードで利用可能になります。
+
+### 主な特徴
+
+- 🌍 **グローバルスコープ**: プロジェクト全体で利用可能
+- 🔄 **自動統合**: `./$types`と自動的に連携
+- 🎯 **標準インターフェース**: SvelteKitが定める特定のインターフェースを拡張
+- 🛡️ **型安全性**: 実行時エラーを未然に防ぐ
+
+## 標準インターフェース
+
+SvelteKitは`App`名前空間に5つの標準インターフェースを提供しています。これらを拡張することで、アプリケーション固有の型定義を追加できます。
+
+### 1. App.Locals - サーバーサイドのリクエスト固有データ
+
+リクエストごとにサーバーサイドで保持するデータの型定義です。認証情報、セッションデータ、データベース接続など、リクエストライフサイクル全体で共有したい情報を格納します。
+
+```typescript
+// src/app.d.ts
+declare global {
+  namespace App {
+    interface Locals {
+      user?: {
+        id: string;
+        email: string;
+        role: 'admin' | 'user' | 'guest';
+      };
+      session?: {
+        id: string;
+        expiresAt: Date;
+      };
+    }
+  }
+}
+```
+
+`hooks.server.ts`で設定し、Load関数やActionsで使用：
+
+```typescript
+// hooks.server.ts
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+  // セッションからユーザー情報を取得
+  event.locals.user = await getUserFromSession(event.cookies);
+  return resolve(event);
+};
+
+// +page.server.ts
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) {
+    throw redirect(303, '/login');
+  }
+  // locals.userが型安全に使える
+  return {
+    userData: locals.user
+  };
+};
+```
+
+### 2. App.PageData - すべてのページで共通のデータ型
+
+アプリケーション全体のページで共通して使用されるデータの型を定義します。メタ情報、フラッシュメッセージ、パンくずリストなど、各ページのLoad関数の返り値に含まれる共通プロパティを管理します。
+
+```typescript
+interface PageData {
+  // すべてのページで利用可能なデータ
+  meta?: {
+    title: string;
+    description: string;
+    ogImage?: string;
+  };
+  flash?: {
+    type: 'success' | 'error' | 'info' | 'warning';
+    message: string;
+    dismissible?: boolean;
+  };
+  breadcrumbs?: Array<{
+    label: string;
+    href: string;
+  }>;
+}
+```
+
+使用例：
+
+```typescript
+// +layout.server.ts
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async () => {
+  return {
+    meta: {
+      title: 'マイアプリ',
+      description: '素晴らしいWebアプリケーション'
+    }
+  };
+};
+```
+
+### 3. App.Error - カスタムエラー型
+
+アプリケーションで発生するエラーの型をカスタマイズします。エラーコード、詳細情報、ステータスなどを追加して、より詳細なエラーハンドリングが可能になります。
+
+```typescript
+interface Error {
+  message: string;
+  code?: 'UNAUTHORIZED' | 'NOT_FOUND' | 'SERVER_ERROR' | 'VALIDATION_ERROR';
+  details?: Record<string, any>;
+  timestamp?: number;
+  requestId?: string;
+}
+```
+
+`error()`関数で使用：
+
+```typescript
+import { error } from '@sveltejs/kit';
+
+// カスタムエラーを投げる
+throw error(404, {
+  message: 'ページが見つかりません',
+  code: 'NOT_FOUND',
+  details: {
+    requestedPath: '/unknown-page'
+  },
+  timestamp: Date.now()
+});
+```
+
+### 4. App.PageState - 履歴エントリの状態
+
+ブラウザの履歴スタックに保存される状態の型定義です。スクロール位置、タブ選択状態、フォーム入力値など、ページ遷移時に保持したいUI状態を管理します。
+
+```typescript
+interface PageState {
+  scrollY?: number;
+  selectedTab?: string;
+  expandedItems?: string[];
+  formData?: Record<string, any>;
+  filterState?: {
+    category?: string;
+    sortBy?: 'name' | 'date' | 'price';
+  };
+}
+```
+
+`pushState`/`replaceState`で使用：
+
+```typescript
+import { pushState, replaceState } from '$app/navigation';
+
+// 状態を保存しながらナビゲーション
+pushState('/products', {
+  scrollY: window.scrollY,
+  selectedTab: 'details',
+  filterState: {
+    category: 'electronics'
+  }
+});
+
+// 現在の履歴エントリの状態を更新
+replaceState('', {
+  formData: {
+    name: 'John',
+    email: 'john@example.com'
+  }
+});
+```
+
+### 5. App.Platform - プラットフォーム固有のAPI
+
+デプロイ先のプラットフォーム（Cloudflare Workers、Vercel、Netlifyなど）固有のAPIや環境変数の型定義です。各プラットフォームの特殊機能を型安全に利用できるようにします。
+
+```typescript
+interface Platform {
+  // Cloudflare Workers の例
+  env?: {
+    DATABASE_URL: string;
+    API_KEY: string;
+    KV_NAMESPACE: KVNamespace;
+    DURABLE_OBJECT: DurableObjectNamespace;
+  };
+  context?: {
+    waitUntil(promise: Promise<any>): void;
+    passThroughOnException(): void;
+  };
+  caches?: CacheStorage;
+}
+```
+
+プラットフォーム固有機能の使用：
+
+```typescript
+// +page.server.ts
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ platform }) => {
+  if (platform?.env?.KV_NAMESPACE) {
+    // Cloudflare KV ストレージを使用
+    const cachedData = await platform.env.KV_NAMESPACE.get('cache-key');
+    if (cachedData) {
+      return JSON.parse(cachedData);
+    }
+  }
+  
+  // 通常のデータ取得処理
+  const data = await fetchData();
+  
+  // バックグラウンドでキャッシュを更新
+  platform?.context?.waitUntil(
+    platform.env?.KV_NAMESPACE?.put('cache-key', JSON.stringify(data))
+  );
+  
+  return data;
+};
+```
+
+## 完全な app.d.ts の例
+
+実際のプロジェクトで使用できる、包括的な`app.d.ts`の設定例です。これらの型定義を組み合わせることで、プロジェクト全体で一貫した型安全性を実現し、開発効率と保守性が大幅に向上します。
+
+```typescript
+// src/app.d.ts
+/// <reference types="@sveltejs/kit" />
+
+declare global {
+  namespace App {
+    // 1. リクエスト固有のサーバーサイドデータ
+    interface Locals {
+      user?: {
+        id: string;
+        email: string;
+        name: string;
+        role: 'admin' | 'user' | 'guest';
+        permissions: string[];
+      };
+      session?: {
+        id: string;
+        expiresAt: Date;
+      };
+      db?: DatabaseConnection;
+      requestId?: string;
+    }
+    
+    // 2. すべてのページで共有されるデータ
+    interface PageData {
+      meta?: {
+        title: string;
+        description: string;
+        keywords?: string[];
+        ogImage?: string;
+      };
+      flash?: {
+        type: 'success' | 'error' | 'info' | 'warning';
+        message: string;
+        dismissible?: boolean;
+      };
+      breadcrumbs?: Array<{
+        label: string;
+        href: string;
+      }>;
+      currentUser?: {
+        name: string;
+        avatar?: string;
+      };
+    }
+    
+    // 3. カスタムエラー型
+    interface Error {
+      message: string;
+      code?: 'UNAUTHORIZED' | 'NOT_FOUND' | 'SERVER_ERROR' | 'VALIDATION_ERROR';
+      details?: Record<string, any>;
+      timestamp?: number;
+      requestId?: string;
+      stack?: string;
+    }
+    
+    // 4. 履歴エントリの状態
+    interface PageState {
+      scrollPosition?: number;
+      selectedTab?: string;
+      expandedItems?: string[];
+      formData?: Record<string, any>;
+      filterState?: {
+        search?: string;
+        category?: string;
+        sortBy?: string;
+        page?: number;
+      };
+    }
+    
+    // 5. プラットフォーム固有のAPI
+    interface Platform {
+      env?: {
+        DATABASE_URL: string;
+        JWT_SECRET: string;
+        API_KEY: string;
+        REDIS_URL?: string;
+        S3_BUCKET?: string;
+      };
+      context?: {
+        waitUntil(promise: Promise<any>): void;
+        passThroughOnException(): void;
+      };
+    }
+  }
+  
+  // カスタムグローバル型
+  type UUID = `${string}-${string}-${string}-${string}-${string}`;
+  type DateString = `${number}-${number}-${number}`;
+  type Timestamp = number;
+  
+  // データベースの型定義例
+  interface DatabaseConnection {
+    query<T>(sql: string, params?: any[]): Promise<T[]>;
+    execute(sql: string, params?: any[]): Promise<void>;
+    transaction<T>(fn: () => Promise<T>): Promise<T>;
+  }
+  
+  // ウィンドウオブジェクトの拡張
+  interface Window {
+    __INITIAL_DATA__?: Record<string, any>;
+    __PUBLIC_ENV__?: Record<string, string>;
+  }
+}
+
+// このファイルがモジュールとして扱われるようにする
+export {};
+```
+
+## ベストプラクティス
+
+### 1. 型定義の整理
+
+```typescript
+// ✅ 良い例：関連する型をグループ化
+interface Locals {
+  auth?: AuthData;
+  db?: DatabaseConnection;
+  cache?: CacheClient;
+}
+
+interface AuthData {
+  user: User;
+  session: Session;
+  permissions: Permission[];
+}
+
+// ❌ 避けるべき：フラットな構造
+interface Locals {
+  userId?: string;
+  userEmail?: string;
+  userName?: string;
+  sessionId?: string;
+  sessionExpiresAt?: Date;
+  // ... 多数のプロパティ
+}
+```
+
+### 2. 型の再利用
+
+```typescript
+// 共通の型を定義して再利用
+type UserRole = 'admin' | 'editor' | 'viewer' | 'guest';
+
+interface BaseUser {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
+interface Locals {
+  user?: BaseUser & {
+    permissions: string[];
+  };
+}
+
+interface PageData {
+  currentUser?: BaseUser & {
+    avatar?: string;
+  };
+}
+```
+
+### 3. 適切なオプショナル型の使用
+
+```typescript
+// ✅ 良い例：必須とオプショナルを明確に区別
+interface Error {
+  message: string;          // 必須
+  code?: string;            // オプショナル
+  details?: Record<string, any>;
+}
+
+// ❌ 避けるべき：すべてオプショナル
+interface Error {
+  message?: string;
+  code?: string;
+  details?: Record<string, any>;
+}
+```
+
+## トラブルシューティング
+
+### 型が認識されない場合
+
+1. **TypeScriptの設定確認**
+
+`tsconfig.json`ファイルの設定を確認：
+
+```typescript
+// tsconfig.json
+const tsConfig = {
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  }
+};
+```
+
+2. **開発サーバーの再起動**
+```bash
+npm run dev
+```
+
+3. **VSCodeの場合**
+- Cmd/Ctrl+Shift+P → "TypeScript: Restart TS Server"
+
+### 型の競合が発生する場合
+
+```typescript
+// namespaceの使用を確認
+declare global {
+  namespace App {
+    // ここに定義
+  }
+}
+
+// exportを忘れずに
+export {};
+```
+
+## まとめ
+
+`app.d.ts`による型定義は、SvelteKitアプリケーションの型安全性の基盤です：
+
+- 🌍 **グローバルな型定義**でプロジェクト全体の一貫性を確保
+- 🛡️ **5つの標準インターフェース**で主要な機能をカバー
+- 🔄 **`./$types`との自動統合**で開発効率が向上
+- 🎯 **プラットフォーム固有の型**も安全に扱える
+
+これらの型定義を適切に設定することで、大規模なアプリケーションでも型安全性を維持しながら効率的な開発が可能になります。
+
+## 次のステップ
+
+- [Load関数とデータフェッチング]({base}/sveltekit/data-loading/) - Load関数での型活用
+- [TypeScript型の自動生成システム]({base}/sveltekit/data-loading/auto-types/) - `./$types`の詳細
+- [フォーム処理とActions]({base}/sveltekit/server/forms/) - Actionsでの型活用

--- a/src/routes/sveltekit/data-loading/+page.md
+++ b/src/routes/sveltekit/data-loading/+page.md
@@ -11,9 +11,9 @@ SvelteKitのLoad関数は、ページやレイアウトに必要なデータを�
 
 ## 学習パス
 
-Load関数とデータフェッチングを段階的に学習できるよう、2つのセクションに分けて解説します。
+Load関数とデータフェッチングを段階的に学習できるよう、3つのセクションに分けて解説します。
 
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-8">
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 my-8">
   <a href="{base}/sveltekit/data-loading/basic/" class="flex no-underline group">
     <div class="p-6 border border-gray-2 dark:border-gray-7 rounded-lg shadow-md hover:shadow-lg hover:border-orange-400 dark:hover:border-orange-400 transition-all cursor-pointer flex flex-col w-full">
       <div class="text-3xl mb-3">📚</div>
@@ -28,6 +28,24 @@ Load関数とデータフェッチングを段階的に学習できるよう、2
         <li>型安全なデータ取得</li>
         <li>親子間のデータ共有</li>
         <li>エラーハンドリング</li>
+      </ul>
+    </div>
+  </a>
+
+  <a href="{base}/sveltekit/data-loading/auto-types/" class="flex no-underline group">
+    <div class="p-6 border border-gray-2 dark:border-gray-7 rounded-lg shadow-md hover:shadow-lg hover:border-orange-400 dark:hover:border-orange-400 transition-all cursor-pointer flex flex-col w-full">
+      <div class="text-3xl mb-3">🔷</div>
+      <h3 class="font-bold text-xl mb-3 text-orange-600 dark:text-orange-400 group-hover:text-orange-700 dark:group-hover:text-orange-300 transition-colors">
+        TypeScript型の自動生成
+      </h3>
+      <p class="text-sm mb-3 text-gray-7 dark:text-gray-3">
+        ./$typesによる型安全な開発とボイラープレート削減の仕組みを理解します。
+      </p>
+      <ul class="text-sm text-gray-6 dark:text-gray-4 space-y-1">
+        <li>PageLoad、Actions等の型</li>
+        <li>ルートパラメータの型推論</li>
+        <li>app.d.tsとの連携</li>
+        <li>トラブルシューティング</li>
       </ul>
     </div>
   </a>

--- a/src/routes/sveltekit/data-loading/auto-types/+page.md
+++ b/src/routes/sveltekit/data-loading/auto-types/+page.md
@@ -78,6 +78,8 @@ RESTful APIエンドポイントを作成するための型定義です。HTTP�
 
 ### 1. Load関数での型定義
 
+動的ルートパラメータを含むページでのデータ取得の例です。`PageLoad`型により、`params.slug`が自動的に`string`型として推論され、タイプミスを防ぎます。
+
 ```typescript
 // src/routes/blog/[slug]/+page.ts
 import type { PageLoad } from './$types';
@@ -96,6 +98,8 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 ### 2. コンポーネントでのデータ受け取り
 
+Load関数から渡されたデータをSvelteコンポーネントで受け取る例です。`PageData`型により、Load関数の返り値の型が自動的に適用され、プロパティへの安全なアクセスが保証されます。
+
 ```svelte
 <!-- src/routes/blog/[slug]/+page.svelte -->
 <script lang="ts">
@@ -113,6 +117,8 @@ export const load: PageLoad = async ({ params, fetch }) => {
 ```
 
 ### 3. Server LoadとForm Actions
+
+サーバーサイドでのデータ取得とフォーム処理を行う例です。`PageServerLoad`で認証チェックとデータ取得を行い、`Actions`でCRUD操作を型安全に実装します。
 
 ```typescript
 // src/routes/admin/posts/+page.server.ts
@@ -169,6 +175,8 @@ export const actions: Actions = {
 
 ### 4. APIエンドポイント
 
+RESTful APIエンドポイントの実装例です。`RequestHandler`型により、HTTPメソッド（GET、PUT、DELETE）ごとのハンドラーが型安全に定義でき、パラメータやレスポンスの型チェックが行われます。
+
 ```typescript
 // src/routes/api/posts/[id]/+server.ts
 import type { RequestHandler } from './$types';
@@ -209,6 +217,8 @@ export const DELETE: RequestHandler = async ({ params }) => {
 
 ### 5. 動的ルートの静的生成
 
+ビルド時に動的ルートのページを静的生成（プリレンダリング）する例です。`EntryGenerator`で生成するパスのリストを定義し、各パスに対してページが事前生成されます。
+
 ```typescript
 // src/routes/products/[category]/[id]/+page.ts
 import type { PageLoad, EntryGenerator } from './$types';
@@ -231,6 +241,8 @@ export const load: PageLoad = async ({ params }) => {
 
 ### 6. パラメータマッチャー
 
+URLパラメータのバリデーションを行うカスタムマッチャーの例です。`ParamMatcher`を使用して、特定のパターン（この例では整数）に一致するパラメータのみを受け入れるルートを作成できます。
+
 ```typescript
 // src/params/integer.ts
 import type { ParamMatcher } from '@sveltejs/kit';
@@ -251,179 +263,13 @@ export const load: PageLoad = async ({ params }) => {
 };
 ```
 
-## 高度な型定義
+## app.d.tsとの連携
 
-SvelteKitの型システムをさらに活用するための高度な設定方法を解説します。`app.d.ts`での型定義は、プロジェクト全体で共有される重要な設定です。
+SvelteKitでは`app.d.ts`ファイルを使用して、プロジェクト全体で共有されるグローバルな型定義を宣言できます。これらの型は`./$types`と自動的に統合され、アプリケーション全体で型安全性を保証します。
 
-### app.d.tsとの連携
-
-`app.d.ts`ファイルは、アプリケーション全体で使用するグローバルな型定義を宣言する場所です。ここで定義した型は`./$types`と自動的に統合され、SvelteKit全体で利用可能になります。
-
-SvelteKitでは`app.d.ts`で定義した型が`./$types`と自動的に統合されます。`App`名前空間に定義できる標準インターフェースは以下の通りです。
-
-#### 1. App.Locals - サーバーサイドのリクエスト固有データ
-
-```typescript
-// src/app.d.ts
-declare global {
-  namespace App {
-    interface Locals {
-      user?: {
-        id: string;
-        email: string;
-        role: 'admin' | 'user' | 'guest';
-      };
-      session?: {
-        id: string;
-        expiresAt: Date;
-      };
-    }
-  }
-}
-```
-
-`hooks.server.ts`で設定し、Load関数やActionsで使用
-
-```typescript
-// hooks.server.ts
-export const handle: Handle = async ({ event, resolve }) => {
-  event.locals.user = await getUserFromSession(event.cookies);
-  return resolve(event);
-};
-
-// +page.server.ts
-export const load: PageServerLoad = async ({ locals }) => {
-  if (!locals.user) {
-    throw redirect(303, '/login');
-  }
-  // locals.userが型安全に使える
-};
-```
-
-#### 2. App.PageData - すべてのページで共通のデータ型
-
-```typescript
-interface PageData {
-  // すべてのページで利用可能なデータ
-  meta?: {
-    title: string;
-    description: string;
-  };
-  flash?: {
-    type: 'success' | 'error' | 'info';
-    message: string;
-  };
-}
-```
-
-#### 3. App.Error - カスタムエラー型
-
-```typescript
-interface Error {
-  message: string;
-  code?: 'UNAUTHORIZED' | 'NOT_FOUND' | 'SERVER_ERROR';
-  details?: Record<string, any>;
-}
-```
-
-`error()`関数で使用
-
-```typescript
-import { error } from '@sveltejs/kit';
-
-throw error(404, {
-  message: 'ページが見つかりません',
-  code: 'NOT_FOUND'
-});
-```
-
-#### 4. App.PageState - 履歴エントリの状態
-
-```typescript
-interface PageState {
-  scrollY?: number;
-  selectedTab?: string;
-  formData?: Record<string, any>;
-}
-```
-
-`pushState`/`replaceState`で使用
-
-```typescript
-import { pushState } from '$app/navigation';
-
-pushState('', {
-  scrollY: window.scrollY,
-  selectedTab: 'details'
-});
-```
-
-#### 5. App.Platform - プラットフォーム固有のAPI
-
-```typescript
-interface Platform {
-  // Cloudflare Workers, Vercel等の環境変数
-  env?: {
-    DATABASE_URL: string;
-    API_KEY: string;
-  };
-  context?: {
-    waitUntil(promise: Promise<any>): void;
-  };
-}
-```
-
-### 完全な app.d.ts の例
-
-実際のプロジェクトで使用できる、包括的な`app.d.ts`の設定例です。これをベースに、プロジェクトの要件に応じてカスタマイズできます。
-
-```typescript
-// src/app.d.ts
-declare global {
-  namespace App {
-    interface Locals {
-      user?: {
-        id: string;
-        email: string;
-        name: string;
-        role: 'admin' | 'user';
-      };
-      session?: string;
-    }
-    
-    interface PageData {
-      flash?: {
-        type: 'success' | 'error' | 'info';
-        message: string;
-      };
-    }
-    
-    interface Error {
-      message: string;
-      code?: string;
-      details?: any;
-    }
-    
-    interface PageState {
-      scrollPosition?: number;
-    }
-    
-    interface Platform {
-      env?: {
-        DATABASE_URL: string;
-        JWT_SECRET: string;
-      };
-    }
-  }
-  
-  // カスタムグローバル型
-  type UUID = `${string}-${string}-${string}-${string}-${string}`;
-}
-
-export {};
-```
-
-これらの型定義は`./$types`の型と自動的に統合され、SvelteKit全体で型安全性が保証されます。
+:::info[グローバル型定義について]
+`app.d.ts`でのグローバル型定義については、[app.d.tsの役割]({base}/sveltekit/basics/global-types/)で詳しく解説しています。App.Locals、App.PageData、App.Error、App.PageState、App.Platformの5つの標準インターフェースの使い方を学びましょう。
+:::
 
 ## ベストプラクティス
 

--- a/src/routes/sveltekit/data-loading/basic/+page.md
+++ b/src/routes/sveltekit/data-loading/basic/+page.md
@@ -234,6 +234,6 @@ export const load: PageLoad = async ({ url, fetch }) => {
 
 ## 次のステップ
 
+- [TypeScript型の自動生成システム](../auto-types/) - TypeScript型の自動生成の仕組み
 - [データフェッチング戦略](../strategies/) - 高度なデータ取得テクニック
 - [フォーム処理とActions](../../server/forms/) - データの送信と処理
-- [TypeScript型の自動生成システム](../../basics/auto-types/) - TypeScript型の自動生成の仕組み


### PR DESCRIPTION
  1. ページの移動
    - /sveltekit/basics/auto-types/ から /sveltekit/data-loading/auto-types/ へ移動
  2. サイドバー構造の更新 (sidebar.ts)
    - 基礎編から「TypeScript型の自動生成システム」を削除
    - データ取得セクションに追加（Load関数の基礎の次に配置）
  3. リンクの修正
    - SvelteKit ランディングページ (/sveltekit/+page.md): - 基礎編カードを「app.d.tsの役割」に変更
      - データ取得カードに「TypeScript型の自動生成」を追加
      - 学習パスのリンクを更新
    - 基礎編ランディングページ (/sveltekit/basics/+page.md):
        - カードを「app.d.tsの役割」に変更
    - Load関数の基本ページ (/sveltekit/data-loading/basic/+page.md): - 次のステップのリンクを相対パスに修正
    - データ取得ランディングページ (/sveltekit/data-loading/+page.md):
        - 学習パスを2つから3つに変更
      - 「TypeScript型の自動生成」カードを追加